### PR TITLE
update for session type changes

### DIFF
--- a/inc_internal/ziti_ctrl.h
+++ b/inc_internal/ziti_ctrl.h
@@ -47,7 +47,7 @@ void ziti_ctrl_get_services(ziti_controller *ctrl, void (*srv_cb)(ziti_service *
 void ziti_ctrl_get_service(ziti_controller *ctrl, const char* service_name, void (*srv_cb)(ziti_service *, ziti_error*, void*), void* ctx);
 
 void ziti_ctrl_get_net_session(
-        ziti_controller *ctrl, ziti_service *service, bool bind,
+        ziti_controller *ctrl, ziti_service *service, const char* type,
         void (*cb)(ziti_net_session *, ziti_error*, void*), void* ctx);
 
 void ziti_ctrl_get_net_sessions(

--- a/inc_internal/ziti_model.h
+++ b/inc_internal/ziti_model.h
@@ -47,7 +47,7 @@ XX(url_tls, string, none, urls.tls)
 #define ZITI_NET_SESSION_MODEL(XX) \
 XX(token, string, none, token)\
 XX(id, string, none, id) \
-XX(hosting, bool, none, hosting) \
+XX(session_type, string, none, type) \
 XX(edge_routers, ziti_edge_router, array, edgeRouters) \
 XX(service_id, string, none, NULL)
 

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -291,14 +291,14 @@ void ziti_ctrl_get_service(ziti_controller *ctrl, const char* service_name, void
 }
 
 void ziti_ctrl_get_net_session(
-        ziti_controller *ctrl, ziti_service *service, bool bind,
+        ziti_controller *ctrl, ziti_service *service, const char* type,
         void (*cb)(ziti_net_session *, ziti_error*, void*), void* ctx) {
 
     char *content = NULL;
     size_t len = mjson_printf(&mjson_print_dynamic_buf, &content,
-            "{%Q: %Q, %Q: %B}",
+            "{%Q: %Q, %Q: %Q}",
             "serviceId", service->id,
-            "hosting", bind);
+            "type", type);
 
     um_http_req_t *req = um_http_req(&ctrl->client, "POST", "/sessions");
     req->resp_cb = ctrl_resp_cb;

--- a/tests/ctrl_tests.cpp
+++ b/tests/ctrl_tests.cpp
@@ -159,7 +159,7 @@ TEST_CASE("controller_test","[integ]") {
             auto *re = static_cast<struct uber_resp_s *>(ctx);
             resp_cb(s, e, &re->service);
             if (e == nullptr) {
-                ziti_ctrl_get_net_session(re->c, s, false, resp_cb, &re->ns);
+                ziti_ctrl_get_net_session(re->c, s, "Dial", resp_cb, &re->ns);
             }
             ziti_ctrl_logout(re->c, logout_cb, &re->logout);
 


### PR DESCRIPTION
fix SDK hosting with 0.8+ ziti

`hosting` flag(boolean) was replaced with `type = {Dial, Bind}` string