### PR TITLE
Idempotent shutdown

### DIFF
--- a/library/channel.c
+++ b/library/channel.c
@@ -104,7 +104,7 @@ void ziti_close_cb(uv_handle_t *h) {
 
 int ziti_channel_close(ziti_channel_t *ch) {
     int r = 0;
-    if (ch->state == Connected) {
+    if (ch->state != Closed) {
         r = uv_mbed_close(&ch->connection, ziti_close_cb);
         ch->state = Closed;
     }

--- a/library/channel.c
+++ b/library/channel.c
@@ -103,7 +103,12 @@ void ziti_close_cb(uv_handle_t *h) {
 }
 
 int ziti_channel_close(ziti_channel_t *ch) {
-    return uv_mbed_close(&ch->connection, ziti_close_cb);
+    int r = 0;
+    if (ch->state == Connected) {
+        r = uv_mbed_close(&ch->connection, ziti_close_cb);
+        ch->state = Closed;
+    }
+    return r;
 }
 
 int ziti_channel_connect(nf_context ziti, const char *url, ch_connect_cb cb, void *cb_ctx) {

--- a/library/ziti.c
+++ b/library/ziti.c
@@ -238,6 +238,7 @@ int NF_shutdown(nf_context ctx) {
     ZITI_LOG(INFO, "Ziti is shutting down");
 
     free_ziti_session(ctx->session);
+    ctx->session = NULL;
 
     uv_timer_stop(&ctx->session_timer);
     ziti_ctrl_close(&ctx->controller);

--- a/library/ziti_ctrl.c
+++ b/library/ziti_ctrl.c
@@ -169,8 +169,10 @@ int ziti_ctrl_init(uv_loop_t *loop, ziti_controller *ctrl, const char *url, tls_
 }
 
 int ziti_ctrl_close(ziti_controller *ctrl) {
-    FREE(ctrl->session);
-    um_http_close(&ctrl->client);
+    if (ctrl->session != NULL) {
+        FREE(ctrl->session);
+        um_http_close(&ctrl->client);
+    }
     return ZITI_OK;
 }
 

--- a/programs/sample_wttr/sample_wttr.c
+++ b/programs/sample_wttr/sample_wttr.c
@@ -93,7 +93,7 @@ int main(int argc, char** argv) {
 
     DIE(NF_init(argv[1], loop, on_nf_init, NULL));
 
-    // loop will finish afger the request is complete and NF_shutdown is called
+    // loop will finish after the request is complete and NF_shutdown is called
     uv_run(loop, UV_RUN_DEFAULT);
 
     printf("========================\n");


### PR DESCRIPTION
Avoid crashing due to double-free, assertions, etc. when NF_shutdown is called twice.